### PR TITLE
Add compat macro for cmake_* commands from @nephros

### DIFF
--- a/macros.kf5.cmake-compat
+++ b/macros.kf5.cmake-compat
@@ -1,0 +1,71 @@
+# Start of cmake backported macros
+
+# define macros for SFOS 4.5 and lower, where the cmake package does not have them:
+# these defines are taken from https://github.com/sailfishos/cmake/blob/master/rpm/macros.cmake.in
+# cross-check with /etc/rpm/macros.cmake
+
+#
+# Macros for cmake
+#
+# %%_cmake_lib_suffix64 -DLIB_SUFFIX=64
+%_cmake_shared_libs -DBUILD_SHARED_LIBS:BOOL=ON
+# %%_cmake_skip_rpath -DCMAKE_SKIP_RPATH:BOOL=ON
+# %%_cmake_version @@CMAKE_VERSION@@
+# %%__cmake cmake
+# %%__ctest ctest
+%__cmake_in_source_build 1
+%_vpath_srcdir .
+%_vpath_builddir %{_target_platform}
+%__cmake_builddir %{!?__cmake_in_source_build:%{_vpath_builddir}}%{?__cmake_in_source_build:.}
+
+
+# - Set default compile flags
+# - CMAKE_*_FLAGS_RELEASE are added *after* the *FLAGS environment variables
+#   and default to -O3 -DNDEBUG.  Strip the -O3 so we can override with *FLAGS
+# - Turn on verbose makefiles so we can see and verify compile flags
+# - Turn off stripping by default so RPM can do it separately
+# - Set default install prefixes and library install directories
+# - Turn on shared libraries by default
+
+# undefine this, and redefine
+%cmake %{nil}
+%cmake \
+  CFLAGS="${CFLAGS:-%optflags}" ; export CFLAGS ; \
+  CXXFLAGS="${CXXFLAGS:-%optflags}" ; export CXXFLAGS ; \
+  FFLAGS="${FFLAGS:-%optflags}" ; export FFLAGS ; \
+  %__cmake \\\
+        %{!?__cmake_in_source_build:-S "%{_vpath_srcdir}"} \\\
+        %{!?__cmake_in_source_build:-B "%{__cmake_builddir}"} \\\
+        -DCMAKE_C_FLAGS_RELEASE:STRING="-DNDEBUG" \\\
+        -DCMAKE_CXX_FLAGS_RELEASE:STRING="-DNDEBUG" \\\
+        -DCMAKE_Fortran_FLAGS_RELEASE:STRING="-DNDEBUG" \\\
+        -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \\\
+        -DCMAKE_INSTALL_DO_STRIP:BOOL=OFF \\\
+        -DCMAKE_INSTALL_PREFIX:PATH=%{_prefix} \\\
+        -DINCLUDE_INSTALL_DIR:PATH=%{_includedir} \\\
+        -DLIB_INSTALL_DIR:PATH=%{_lib} \\\
+        -DSYSCONF_INSTALL_DIR:PATH=%{_sysconfdir} \\\
+        -DSHARE_INSTALL_PREFIX:PATH=%{_datadir} \\\
+%if "%{?_lib}" == "lib64" \
+        %{?_cmake_lib_suffix64} \\\
+%endif \
+        %{?_cmake_shared_libs}
+
+%cmake_build \
+  %__cmake --build "%{__cmake_builddir}" %{?_smp_mflags} --verbose
+
+%cmake_install \
+  DESTDIR="%{buildroot}" %__cmake --install "%{__cmake_builddir}"
+
+# %%ctest(:-:h:j:u:v:A:C:D:E:F:H:I:L:M:N:O:Q:R:S:T:U:V:) \
+#   %%__ctest --test-dir "%%{__cmake_builddir}" --output-on-failure --force-new-ctest-process %%{?_smp_mflags} %%{**}
+
+
+# %%cmake@@CMAKE_MAJOR_VERSION@@ %cmake
+# %%cmake@@CMAKE_MAJOR_VERSION@@_build %cmake_build
+# %%cmake@@CMAKE_MAJOR_VERSION@@_install %cmake_install
+# %%ctest@@CMAKE_MAJOR_VERSION@@(:-:h:j:u:v:A:C:D:E:F:H:I:L:M:N:O:Q:R:S:T:U:V:) \
+# %  %ctest %{**}
+
+# End of cmake backported macros
+

--- a/rpm/kf5.spec
+++ b/rpm/kf5.spec
@@ -27,6 +27,11 @@ RPM macros for building KDE Frameworks 5 packages.
 
 %install
 install -Dpm644 macros.kf5 %{buildroot}%{_rpmconfigdir}/macros.d/macros.kf5
+# add compat macros:
+%if 0%{?sailfishos_version} < 40600
+cat macros.kf5.cmake-compat >> %{buildroot}%{_rpmconfigdir}/macros.d/macros.kf5
+%endif
+
 sed -i \
   -e "s|@@KF5_VERSION@@|%{version}|g" \
   %{buildroot}%{_rpmconfigdir}/macros.d/macros.kf5


### PR DESCRIPTION
This provides the cmake_* macros for older (<= 4.5) sailfish releases